### PR TITLE
Lukeswart/api dependency updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ django-cache-url==1.0.0
 
 # File Storage
 boto==2.39.0
-django-storages==1.1.8
+django-storages==1.4
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,10 +77,10 @@ requests>=2.9.1
 # Testing, validating, and debugging
 # ==============================
 
-nose
+nose==1.3.7
 django-nose==1.3
-mock
-mock_django
+mock==1.3.0
+mock_django==0.6.10
 responses==0.5.1
 django-debug-toolbar==1.2.1
 raven==5.11.0  # For Sentry error logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@
 
 Django==1.7.1
 gevent==1.0
-gunicorn==18.0
-newrelic==2.16.0.12
+gunicorn==19.4
+newrelic==2.60.0.46
 dj_static==0.0.6
 
 
@@ -14,8 +14,8 @@ dj_static==0.0.6
 # Background processing
 # ==============================
 
-celery==3.1.13
-django-celery==3.1.10
+celery==3.1.20
+django-celery==3.1.17
 
 
 
@@ -24,10 +24,10 @@ django-celery==3.1.10
 # ==============================
 
 # DB Settings and Management
-psycopg2==2.5.1
+psycopg2==2.6.1
 psycogreen==1.0
-south==1.0.1
-dj-database-url==0.2.2
+south==1.0.2
+dj-database-url==0.4.0
 django-object-actions==0.4.0
 
 # Caching
@@ -35,7 +35,7 @@ django-redis==4.2.0
 django-cache-url==1.0.0
 
 # File Storage
-boto==2.36.0
+boto==2.39.0
 django-storages==1.1.8
 
 
@@ -44,7 +44,7 @@ django-storages==1.1.8
 # User Accounts and Social Media
 # ==============================
 
-python-social-auth==0.1.23
+python-social-auth==0.2.14
 # Use fork of oauth2-provider, for Django 1.7 compatibility
 # django-oauth2-provider==0.2.6.1
 git+https://github.com/glassresistor/django-oauth2-provider.git@4269205#egg=django-oauth2-provider==0.2.7-dev
@@ -59,17 +59,17 @@ django-cors-headers==0.12
 djangorestframework==2.3.12
 djangorestframework-csv==1.3.0
 git+https://github.com/mjumbewu/django-rest-framework-bulk.git@84a5d6c#egg=djangorestframework-bulk==0.1.3
-six>=1.4.1
+six>=1.10.0
 markdown  # For browsable API docs
-python-dateutil==2.2
-ujson==1.33
-Pillow==2.6.1
+python-dateutil==2.5
+ujson==1.35
+Pillow==3.1.1
 
 # The Django admin interface
 django-ace==1.0.1
 
 # The manager interface
-requests>=1.2.0
+requests>=2.9.1
 
 
 
@@ -81,12 +81,12 @@ nose
 django-nose==1.3
 mock
 mock_django
-responses==0.2.2
+responses==0.5.1
 django-debug-toolbar==1.2.1
-raven==4.2.1  # For Sentry error logging
+raven==5.11.0  # For Sentry error logging
 
 
 # - - - - - - - - - - - - - - - -
 
 # For DRF 0.4 (deprecated)
-URLObject>=0.6.0
+URLObject>=2.4.0

--- a/src/sa_api_v2/migrations/0003_auto_20160304_0527.py
+++ b/src/sa_api_v2/migrations/0003_auto_20160304_0527.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import sa_api_v2.models.core
+import storages.backends.s3boto
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sa_api_v2', '0002_auto__add_protected_access_flag'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='attachment',
+            name='file',
+            field=models.FileField(storage=storages.backends.s3boto.S3BotoStorage(), upload_to=sa_api_v2.models.core.timestamp_filename),
+            preserve_default=True,
+        ),
+    ]


### PR DESCRIPTION
Non-breaking updates to our Django 1.7 dependencies

Note that updating `django-storages` allows us to run `manage.py migrate` without errors. Without this update, we were getting an error about our S3 attachment model. After the update, we were able to create a new migration with `manage.py makemigrations` and `manage.py migrate` works fine.