### PR TITLE
Lukeswart/django18 upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,7 @@ django-nose==1.4.3
 mock==1.3.0
 mock_django==0.6.10
 responses==0.5.1
-django-debug-toolbar==1.3.1
+django-debug-toolbar==1.3.0
 raven==5.11.0  # For Sentry error logging
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ django-cache-url==1.0.0
 
 # File Storage
 boto==2.39.0
-django-storages==1.1.8
+django-storages==1.4
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,10 +77,10 @@ requests>=2.9.1
 # Testing, validating, and debugging
 # ==============================
 
-nose
+nose==1.3.7
 django-nose==1.3
-mock
-mock_django
+mock==1.3.0
+mock_django==0.6.10
 responses==0.5.1
 django-debug-toolbar==1.2.1
 raven==5.11.0  # For Sentry error logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@
 
 Django==1.7.1
 gevent==1.0
-gunicorn==18.0
-newrelic==2.16.0.12
+gunicorn==19.4
+newrelic==2.60.0.46
 dj_static==0.0.6
 
 
@@ -14,8 +14,8 @@ dj_static==0.0.6
 # Background processing
 # ==============================
 
-celery==3.1.13
-django-celery==3.1.10
+celery==3.1.20
+django-celery==3.1.17
 
 
 
@@ -24,10 +24,10 @@ django-celery==3.1.10
 # ==============================
 
 # DB Settings and Management
-psycopg2==2.5.1
+psycopg2==2.6.1
 psycogreen==1.0
-south==1.0.1
-dj-database-url==0.2.2
+south==1.0.2
+dj-database-url==0.4.0
 django-object-actions==0.4.0
 
 # Caching
@@ -35,7 +35,7 @@ django-redis==4.2.0
 django-cache-url==1.0.0
 
 # File Storage
-boto==2.36.0
+boto==2.39.0
 django-storages==1.1.8
 
 
@@ -44,7 +44,7 @@ django-storages==1.1.8
 # User Accounts and Social Media
 # ==============================
 
-python-social-auth==0.1.23
+python-social-auth==0.2.14
 # Use fork of oauth2-provider, for Django 1.7 compatibility
 # django-oauth2-provider==0.2.6.1
 git+https://github.com/glassresistor/django-oauth2-provider.git@4269205#egg=django-oauth2-provider==0.2.7-dev
@@ -59,17 +59,17 @@ django-cors-headers==0.12
 djangorestframework==2.3.12
 djangorestframework-csv==1.3.0
 git+https://github.com/mjumbewu/django-rest-framework-bulk.git@84a5d6c#egg=djangorestframework-bulk==0.1.3
-six>=1.4.1
+six>=1.10.0
 markdown  # For browsable API docs
-python-dateutil==2.2
-ujson==1.33
-Pillow==2.6.1
+python-dateutil==2.5
+ujson==1.35
+Pillow==3.1.1
 
 # The Django admin interface
 django-ace==1.0.1
 
 # The manager interface
-requests>=1.2.0
+requests>=2.9.1
 
 
 
@@ -81,12 +81,12 @@ nose
 django-nose==1.3
 mock
 mock_django
-responses==0.2.2
+responses==0.5.1
 django-debug-toolbar==1.2.1
-raven==4.2.1  # For Sentry error logging
+raven==5.11.0  # For Sentry error logging
 
 
 # - - - - - - - - - - - - - - - -
 
 # For DRF 0.4 (deprecated)
-URLObject>=0.6.0
+URLObject>=2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,19 +2,18 @@
 # Web server
 # ==============================
 
-Django==1.7.1
-gevent==1.0
-gunicorn==19.4
+Django==1.8.10
+gevent==1.0.2
+gunicorn==19.4.5
 newrelic==2.60.0.46
-dj_static==0.0.6
-
+dj-static==0.0.6
 
 
 # ==============================
 # Background processing
 # ==============================
 
-celery==3.1.20
+celery==3.1.21
 django-celery==3.1.17
 
 
@@ -28,10 +27,10 @@ psycopg2==2.6.1
 psycogreen==1.0
 south==1.0.2
 dj-database-url==0.4.0
-django-object-actions==0.4.0
+django-object-actions==0.8.0
 
 # Caching
-django-redis==4.2.0
+django-redis==4.3.0
 django-cache-url==1.0.0
 
 # File Storage
@@ -48,7 +47,7 @@ python-social-auth==0.2.14
 # Use fork of oauth2-provider, for Django 1.7 compatibility
 # django-oauth2-provider==0.2.6.1
 git+https://github.com/glassresistor/django-oauth2-provider.git@4269205#egg=django-oauth2-provider==0.2.7-dev
-django-cors-headers==0.12
+django-cors-headers==1.1.0
 
 
 
@@ -56,7 +55,7 @@ django-cors-headers==0.12
 # REST API
 # ==============================
 
-djangorestframework==2.3.12
+djangorestframework==2.4.8
 djangorestframework-csv==1.3.0
 git+https://github.com/mjumbewu/django-rest-framework-bulk.git@84a5d6c#egg=djangorestframework-bulk==0.1.3
 six>=1.10.0
@@ -78,11 +77,11 @@ requests>=2.9.1
 # ==============================
 
 nose==1.3.7
-django-nose==1.3
+django-nose==1.4.3
 mock==1.3.0
 mock_django==0.6.10
 responses==0.5.1
-django-debug-toolbar==1.2.1
+django-debug-toolbar==1.3.1
 raven==5.11.0  # For Sentry error logging
 
 

--- a/src/sa_api_v2/migrations/0003_auto_20160304_0527.py
+++ b/src/sa_api_v2/migrations/0003_auto_20160304_0527.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import sa_api_v2.models.core
+import storages.backends.s3boto
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sa_api_v2', '0002_auto__add_protected_access_flag'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='attachment',
+            name='file',
+            field=models.FileField(storage=storages.backends.s3boto.S3BotoStorage(), upload_to=sa_api_v2.models.core.timestamp_filename),
+            preserve_default=True,
+        ),
+    ]


### PR DESCRIPTION
Upgrade to Django 1.8

BUT, this doesn't work. We are getting the following error:

>There is no South database module 'south.db.postgresql_psycopg2' for your database. Please either choose a supported database, check for SOUTH_DATABASE_ADAPTER[S] settings, or remove South from INSTALLED_APPS.

And if we try uninstalling South, we get the stacktrace below. But, it seems that the best bet is to uninstall South.

```
# after running `pip uninstall south`:
(smartercleanup-api-1.8) /home/.../smartercleanup-api/src$ ./manage.py test
/home/me/projects/SmarterCleanup/smartercleanup-api/src/sa_api_v2/models/caching.py:2: RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.
  from django.utils.importlib import import_module

/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/forms/fields.py:1230: RemovedInDjango19Warning: IPAddressField has been deprecated. Use GenericIPAddressField instead.
  RemovedInDjango19Warning)

nosetests --verbosity=1
Creating test database for alias 'default'...
Got an error creating the test database: database "test_shareabouts_v2" already exists

Type 'yes' if you would like to try deleting the test database 'test_shareabouts_v2', or 'no' to cancel: yes
Destroying old test database 'default'...
Traceback (most recent call last):
  File "./manage.py", line 16, in <module>
    execute_from_command_line(sys.argv)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/core/management/__init__.py", line 346, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/core/management/commands/test.py", line 30, in run_from_argv
    super(Command, self).run_from_argv(argv)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/core/management/base.py", line 394, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/core/management/commands/test.py", line 74, in execute
    super(Command, self).execute(*args, **options)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/raven/contrib/django/management/__init__.py", line 41, in new_execute
    return original_func(self, *args, **kwargs)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/core/management/commands/test.py", line 90, in handle
    failures = test_runner.run_tests(test_labels)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django_nose/runner.py", line 403, in run_tests
    result = self.run_suite(nose_argv)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django_nose/runner.py", line 335, in run_suite
    addplugins=plugins_to_add)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/nose/core.py", line 121, in __init__
    **extra_args)
  File "/usr/lib64/python2.7/unittest/main.py", line 95, in __init__
    self.runTests()
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/nose/core.py", line 207, in runTests
    result = self.testRunner.run(self.test)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/nose/core.py", line 50, in run
    wrapper = self.config.plugins.prepareTest(test)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/nose/plugins/manager.py", line 99, in __call__
    return self.call(*arg, **kw)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/nose/plugins/manager.py", line 167, in simple
    result = meth(*arg, **kw)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django_nose/plugin.py", line 82, in prepareTest
    self.old_names = self.runner.setup_databases()
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django_nose/runner.py", line 590, in setup_databases
    return super(NoseTestSuiteRunner, self).setup_databases()
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/test/runner.py", line 166, in setup_databases
    **kwargs
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/test/runner.py", line 370, in setup_databases
    serialize=connection.settings_dict.get("TEST", {}).get("SERIALIZE", True),
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/db/backends/base/creation.py", line 368, in create_test_db
    test_flush=not keepdb,
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/core/management/__init__.py", line 120, in call_command
    return command.execute(*args, **defaults)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/raven/contrib/django/management/__init__.py", line 41, in new_execute
    return original_func(self, *args, **kwargs)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/core/management/commands/migrate.py", line 179, in handle
    created_models = self.sync_apps(connection, executor.loader.unmigrated_apps)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/core/management/commands/migrate.py", line 318, in sync_apps
    cursor.execute(statement)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/db/utils.py", line 98, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/home/me/.virtualenvs/smartercleanup-api-1.8/lib/python2.7/site-packages/django/db/backends/utils.py", line 62, in execute
    return self.cursor.execute(sql)
django.db.utils.ProgrammingError: relation "auth_user" does not exist
```
