### PR TITLE
Fix test request/username headers, and test conditions

### DIFF
--- a/src/remote_client_user/tests.py
+++ b/src/remote_client_user/tests.py
@@ -42,7 +42,7 @@ class RemoteClientUserTests (TestCase):
 
     def test_no_auth_with_client_with_no_permissions(self):
         User = get_user_model()
-        user = User.objects.create_user(username='dvalpey', email='dvalpey@example.com', password='!')
+        user = User.objects.create_user(username='mjumbewu', email='mjumbewu@example.com', password='!')
         
         Application.objects.create(client_id='abc', client_secret='123', user_id=user.id, client_type=Application.CLIENT_CONFIDENTIAL, redirect_uris='http://www.example.com')
 
@@ -67,10 +67,10 @@ class RemoteClientUserTests (TestCase):
 
     def test_no_auth_with_client_with_no_signup_permissions(self):
         User = get_user_model()
-        user = User.objects.create_user(username='dvalpey', email='dvalpey@example.com', password='!')
+        user = User.objects.create_user(username='mjumbewu', email='mjumbewu@example.com', password='!')
         
         client = Application.objects.create(client_id='abc', client_secret='123', user_id=user.id, client_type=Application.CLIENT_CONFIDENTIAL, redirect_uris='http://www.example.com')
-        ClientPermissions.objects.create(client=client, allow_remote_signin=True)
+        ClientPermissions.objects.create(client=client, allow_remote_signin=False)
 
         request = RequestFactory().get('')
         request.META['HTTP_AUTHORIZATION'] = 'Remote ' + base64.encodestring('abc;123;mjumbewu;mjumbewu@example.com').strip()
@@ -80,7 +80,7 @@ class RemoteClientUserTests (TestCase):
 
     def test_auth_with_client_with_signup_permissions(self):
         User = get_user_model()
-        user = User.objects.create_user(username='dvalpey', email='dvalpey@example.com', password='!')
+        user = User.objects.create_user(username='mjumbewu', email='mjumbewu@example.com', password='!')
         
         client = Application.objects.create(client_id='abc', client_secret='123', user_id=user.id, client_type=Application.CLIENT_CONFIDENTIAL, redirect_uris='http://www.example.com')
         ClientPermissions.objects.create(client=client, allow_remote_signin=True, allow_remote_signup=True)


### PR DESCRIPTION
 - The usernames from the user and the HTTP_AUTHORIZATION headers should match, which is done in this commit.
 - Also fixed the `test_no_auth_with_client_with_no_signup_permissions` test by setting `allow_remote_signin` to False in the permissions.