### PR TITLE
Fix 'NameError: name 'queryset' is not defined' error

### DIFF
--- a/src/sa_api_v2/serializers.py
+++ b/src/sa_api_v2/serializers.py
@@ -136,6 +136,8 @@ class ShareaboutsRelatedField (ShareaboutsFieldMixin, serializers.HyperlinkedRel
     def __init__(self, *args, **kwargs):
         if self.view_name is not None:
             kwargs['view_name'] = self.view_name
+        if self.queryset is not None:
+            kwargs['queryset'] = self.queryset
         super(ShareaboutsRelatedField, self).__init__(*args, **kwargs)
 
     def to_native(self, obj):
@@ -486,7 +488,7 @@ class SimpleGroupSerializer (BaseGroupSerializer):
         exclude = ('id', 'dataset', 'submitters')
 
 class GroupSerializer (BaseGroupSerializer):
-    dataset = DataSetRelatedField()
+    dataset = DataSetRelatedField(queryset=models.Group.objects.all())
 
     class Meta (BaseGroupSerializer.Meta):
         pass
@@ -823,7 +825,7 @@ class SimplePlaceSerializer (BasePlaceSerializer):
 
 class PlaceSerializer (BasePlaceSerializer, serializers.HyperlinkedModelSerializer):
     url = PlaceIdentityField()
-    dataset = DataSetRelatedField()
+    dataset = DataSetRelatedField(queryset=models.Place.objects.all())
     submitter = UserSerializer(read_only=False)
 
     class Meta (BasePlaceSerializer.Meta):
@@ -865,7 +867,7 @@ class SimpleSubmissionSerializer (BaseSubmissionSerializer):
 
 class SubmissionSerializer (BaseSubmissionSerializer, serializers.HyperlinkedModelSerializer):
     url = SubmissionIdentityField()
-    dataset = DataSetRelatedField()
+    dataset = DataSetRelatedField(queryset=models.Submission.objects.all())
     set = SubmissionSetRelatedField(source='*')
     place = PlaceRelatedField()
     submitter = UserSerializer()


### PR DESCRIPTION
 - queryset is now a required for non read-only HyperlinkedIdentityField: http://www.django-rest-framework.org/api-guide/relations/#hyperlinkedrelatedfield
 - We are getting a new bug for the required 'view_name' argument to PlaceSerializer.url() (PlaceIdentityField)