### PR TITLE
Explicitly define 'view_name' and 'queryset' attrs

### DIFF
--- a/src/sa_api_v2/serializers.py
+++ b/src/sa_api_v2/serializers.py
@@ -166,16 +166,19 @@ class DataSetKeysRelatedField (ShareaboutsRelatedField):
 class UserRelatedField (ShareaboutsRelatedField):
     view_name = 'user-detail'
     url_arg_names = ('owner_username',)
+    queryset = models.User.objects.all()
 
 
 class PlaceRelatedField (ShareaboutsRelatedField):
     view_name = 'place-detail'
     url_arg_names = ('owner_username', 'dataset_slug', 'place_id')
+    queryset = models.Place.objects.all()
 
 
 class SubmissionSetRelatedField (ShareaboutsRelatedField):
     view_name = 'submission-list'
     url_arg_names = ('owner_username', 'dataset_slug', 'place_id', 'submission_set_name')
+    queryset = models.Submission.objects.all()
 
 
 class ShareaboutsIdentityField (ShareaboutsFieldMixin, serializers.HyperlinkedIdentityField):
@@ -202,6 +205,7 @@ class ShareaboutsIdentityField (ShareaboutsFieldMixin, serializers.HyperlinkedId
 
 class PlaceIdentityField (ShareaboutsIdentityField):
     url_arg_names = ('owner_username', 'dataset_slug', 'place_id')
+    view_name = 'place-detail'
 
 
 class SubmissionSetIdentityField (ShareaboutsIdentityField):
@@ -221,10 +225,12 @@ class DataSetSubmissionSetIdentityField (ShareaboutsIdentityField):
 
 class SubmissionIdentityField (ShareaboutsIdentityField):
     url_arg_names = ('owner_username', 'dataset_slug', 'place_id', 'submission_set_name', 'submission_id')
+    view_name = 'submission-detail'
 
 
 class DataSetIdentityField (ShareaboutsIdentityField):
     url_arg_names = ('owner_username', 'dataset_slug')
+    view_name = 'dataset-detail'
 
 
 class AttachmentFileField (serializers.FileField):


### PR DESCRIPTION
 - serializers.HyperlinkedIdentityField and serializers.HyperlinkedRelatedField now require 'view_name' and 'queryset' to be explicitly defined as kwargs
 - For these instances, we explicitly define the correct 'view_name' and 'queryset' params as attributes, which are then passed as kwargs to the appropriate rest_framework.serializers field.
 - We are now getting an error when calling `pagination.NextPageField(source='*')` on the rest_framework.pagination module: `AttributeError: 'module' object has no attribute 'NextPageField'`