### PR TITLE
Pagination serializer updates for DRF3.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,6 +58,7 @@ django-cors-headers==1.1.0
 
 djangorestframework==3.3.3
 djangorestframework-csv==1.4.1
+djangorestframework-jsonp>=1.0.0,<1.1
 # git+https://github.com/mjumbewu/django-rest-framework-bulk.git@84a5d6c#egg=djangorestframework-bulk==0.1.3
 # replace forked drf-bulk with main version
 djangorestframework-bulk==0.2

--- a/src/sa_api_v2/renderers.py
+++ b/src/sa_api_v2/renderers.py
@@ -1,5 +1,6 @@
 import ujson as json
-from rest_framework.renderers import JSONRenderer, JSONPRenderer
+from rest_framework.renderers import JSONRenderer
+from rest_framework_jsonp.renderers import JSONPRenderer
 from rest_framework_csv.renderers import CSVRenderer
 from django.contrib.gis.geos import GEOSGeometry
 

--- a/src/sa_api_v2/serializers.py
+++ b/src/sa_api_v2/serializers.py
@@ -1010,19 +1010,17 @@ class ActionSerializer (EmptyModelSerializer, serializers.ModelSerializer):
 # ----------------------
 #
 
-class PaginationMetadataSerializer (serializers.Serializer):
-    length = serializers.Field(source='paginator.count')
-    next = pagination.NextPageField(source='*')
-    previous = pagination.PreviousPageField(source='*')
-    page = serializers.Field(source='number')
-    num_pages = serializers.Field(source='paginator.num_pages')
-
-
-class PaginatedResultsSerializer (pagination.BasePaginationSerializer):
-    metadata = PaginationMetadataSerializer(source='*')
+# TODO: We may need to adjust our pagination serializer, which previously
+# used a 'metadata' key. Since pagination is now built into DRF3.3, we'll
+# need to adjust our views/tests accordingly
+# (see:
+# http://www.django-rest-framework.org/api-guide/pagination/#pagenumberpagination)
+# TODO: Do we even need this class?
+class PaginatedResultsSerializer (pagination.PageNumberPagination):
     many = True
 
 
+# TODO: Do we even need this class?
 class FeatureCollectionSerializer (PaginatedResultsSerializer):
     results_field = 'features'
 
@@ -1030,4 +1028,3 @@ class FeatureCollectionSerializer (PaginatedResultsSerializer):
         data = super(FeatureCollectionSerializer, self).to_native(obj)
         data['type'] = 'FeatureCollection'
         return data
-

--- a/src/sa_api_v2/views/base_views.py
+++ b/src/sa_api_v2/views/base_views.py
@@ -995,7 +995,12 @@ class PlaceListView (CachedResourceMixin, LocatedResourceMixin, OwnedResourceMix
 
     model = models.Place
     serializer_class = serializers.PlaceSerializer
-    pagination_serializer_class = serializers.FeatureCollectionSerializer
+    # TODO: 'pagination_serializer_class' is deprecated;
+    # using 'pagination_class' instead.
+    # But we'll need to fix other parts of our views and tests as needed.
+    # (see: http://www.django-rest-framework.org/topics/3.1-announcement/)
+    # pagination_serializer_class = serializers.FeatureCollectionSerializer
+    pagination_class = serializers.FeatureCollectionSerializer
     renderer_classes = (renderers.GeoJSONRenderer, renderers.GeoJSONPRenderer) + OwnedResourceMixin.renderer_classes[2:]
     parser_classes = (parsers.GeoJSONParser,) + OwnedResourceMixin.parser_classes[1:]
 

--- a/src/sa_api_v2/views/base_views.py
+++ b/src/sa_api_v2/views/base_views.py
@@ -15,7 +15,8 @@ from rest_framework import (views, permissions, mixins, authentication,
 from rest_framework.negotiation import DefaultContentNegotiation
 from rest_framework.parsers import JSONParser, FormParser, MultiPartParser
 from rest_framework.response import Response
-from rest_framework.renderers import JSONRenderer, JSONPRenderer, BrowsableAPIRenderer
+from rest_framework.renderers import JSONRenderer, BrowsableAPIRenderer
+from rest_framework_jsonp.renderers import JSONPRenderer
 from rest_framework.request import Request
 from rest_framework.exceptions import APIException
 from rest_framework_bulk import generics as bulk_generics


### PR DESCRIPTION
 - Replaced custom `PaginationMetadataSerializer` class with built-in `PageNumberPagination` (http://www.django-rest-framework.org/api-guide/pagination/#pagenumberpagination)
 - Replaced deprecated `pagination_serializer_class` with `pagination_class` (http://www.django-rest-framework.org/topics/3.1-announcement/)
 - Using `djangorestframework-jsonp` module (jsonp renderer is no longer built into DRF) and added `from rest_framework_jsonp.renderers import JSONPRenderer`.