### PR TITLE
Remove IsOwnerOrReadOnly permission class from OwnedResourceMixin

### DIFF
--- a/src/sa_api_v2/views/base_views.py
+++ b/src/sa_api_v2/views/base_views.py
@@ -250,6 +250,9 @@ class IsAllowedByDataPermissions(permissions.BasePermission):
         if request.method == 'OPTIONS':
             return True
 
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
         # Let the owner do whatever they want
         if is_owner(request.user, request):
             return True

--- a/src/sa_api_v2/views/base_views.py
+++ b/src/sa_api_v2/views/base_views.py
@@ -561,7 +561,7 @@ class OwnedResourceMixin (ClientAuthenticationMixin, CorsEnabledMixin):
     """
     renderer_classes = (JSONRenderer, JSONPRenderer, BrowsableAPIRenderer, renderers.PaginatedCSVRenderer)
     parser_classes = (JSONParser, FormParser, MultiPartParser)
-    permission_classes = (IsOwnerOrReadOnly, IsAllowedByDataPermissions)
+    permission_classes = (IsAllowedByDataPermissions, )
     authentication_classes = (authentication.BasicAuthentication, authentication.OAuth2Authentication, ShareaboutsSessionAuth)
     client_authentication_classes = (apikey.auth.ApiKeyAuthentication, cors.auth.OriginAuthentication)
     content_negotiation_class = ShareaboutsContentNegotiation


### PR DESCRIPTION
Addresses #52 -- but we should talk about this a bit before merging!

This PR removes the `IsOwnerOrReadOnly` permission class from the list of permission classes in `OwnedResourceMixin`, and moves a check against `permissions.SAFE_METHODS` to the `isAllowedByDataPermissions` class.

It turns out that _all_ permissions in the list of permissions classes must return `True` for the REST Framework to allow a given request (see [here](http://www.django-rest-framework.org/api-guide/permissions/)).

Except in the case of `permissions.SAFE_METHODS`, the `IsOwnerOrReadOnly` permission class will return `False` unless, as the name suggests, the request comes from the a dataset's owner or the dataset is read only.

To support our in-browser editor, we want any number of users who have been added to a dataset's `administrators` group to have PUT and DELETE privileges. If I'm understanding the API correctly, we need to loosen the privileges a bit to make this happen.

I also discovered that a dataset's `Group permissions` set via the Django admin panel cannot be left blank--as the help box would suggest!--but rather must be set to `*`. Otherwise, [this](https://github.com/smartercleanup/api/blob/master/src/sa_api_v2/models/data_permissions.py#L152) line will fail, and the `any_allow` method will return `False`.

@LukeSwart -- I'm a little out of my element here, so it would be great to talk about this a bit when you have some time!
